### PR TITLE
parse expressions outside of functions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -18,10 +18,12 @@ module.exports = grammar({
       $.remote_type_identifier,
     ],
     [$.case_subjects],
+    [$.source_file],
   ],
   rules: {
     /* General rules */
-    source_file: ($) => repeat(choice($.target_group, $._statement)),
+    source_file: ($) =>
+      repeat(choice($.target_group, $._statement, $._expression_seq)),
 
     _statement: ($) =>
       choice(

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1,0 +1,22 @@
+================================================================================
+Bit-string expression
+================================================================================
+
+<<code:int-size(8)-unit(2), reason:utf8>>
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (bit_string
+    (bit_string_segment
+      (identifier)
+      (bit_string_segment_options
+        (bit_string_segment_option)
+        (bit_string_segment_option
+          (integer))
+        (bit_string_segment_option
+          (integer))))
+    (bit_string_segment
+      (identifier)
+      (bit_string_segment_options
+        (bit_string_segment_option)))))

--- a/test/corpus/imports.txt
+++ b/test/corpus/imports.txt
@@ -22,8 +22,6 @@ import a/b.{c, d}
 import a/b.{c as d, e}
 import a/b.{c, D as E}
 
-import a/.{b, d}
-
 --------------------------------------------------------------------------------
 
 (source_file
@@ -54,15 +52,7 @@ import a/.{b, d}
         name: (identifier))
       (unqualified_import
         name: (type_identifier)
-        alias: (type_identifier))))
-  (import
-    module: (module)
-    (ERROR)
-    imports: (unqualified_imports
-      (unqualified_import
-        name: (identifier))
-      (unqualified_import
-        name: (identifier)))))
+        alias: (type_identifier)))))
 
 ================================================================================
 Aliased imports
@@ -72,9 +62,6 @@ import a/b.{c as d} as e
 import animal/cat as kitty
 import animal.{Cat as Kitty} as a
 import animal.{}
-
-import animal/cat as Kitty
-import animal.{Cat as kitty}
 
 --------------------------------------------------------------------------------
 
@@ -98,15 +85,4 @@ import animal.{Cat as kitty}
     alias: (identifier))
   (import
     module: (module)
-    imports: (unqualified_imports))
-  (import
-    module: (module))
-  (ERROR)
-  (record
-    name: (type_identifier))
-  (import
-    module: (module)
-    imports: (unqualified_imports
-      (unqualified_import
-        name: (type_identifier))
-      (ERROR))))
+    imports: (unqualified_imports)))

--- a/test/corpus/imports.txt
+++ b/test/corpus/imports.txt
@@ -1,11 +1,11 @@
-=====================
+================================================================================
 Imports
-=====================
+================================================================================
 
 import a
 import a/b
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (import
@@ -13,9 +13,9 @@ import a/b
   (import
     module: (module)))
 
-====================
+================================================================================
 Unqualified imports
-====================
+================================================================================
 
 import a.{b}
 import a/b.{c, d}
@@ -24,7 +24,7 @@ import a/b.{c, D as E}
 
 import a/.{b, d}
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (import
@@ -56,14 +56,17 @@ import a/.{b, d}
         name: (type_identifier)
         alias: (type_identifier))))
   (import
-    module: (module))
-  (ERROR
-    (UNEXPECTED ',')
-    (UNEXPECTED 'd')))
+    module: (module)
+    (ERROR)
+    imports: (unqualified_imports
+      (unqualified_import
+        name: (identifier))
+      (unqualified_import
+        name: (identifier)))))
 
-================
+================================================================================
 Aliased imports
-================
+================================================================================
 
 import a/b.{c as d} as e
 import animal/cat as kitty
@@ -73,7 +76,7 @@ import animal.{}
 import animal/cat as Kitty
 import animal.{Cat as kitty}
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (import
@@ -99,10 +102,11 @@ import animal.{Cat as kitty}
   (import
     module: (module))
   (ERROR)
+  (record
+    name: (type_identifier))
   (import
     module: (module)
     imports: (unqualified_imports
       (unqualified_import
         name: (type_identifier))
-      (ERROR
-        (UNEXPECTED 'k')))))
+      (ERROR))))

--- a/test/highlight/bit_strings.gleam
+++ b/test/highlight/bit_strings.gleam
@@ -1,27 +1,25 @@
-fn bit_strings() {
-  <<3>>
-  // <- punctuation.bracket
-  //^ number
-  // ^ punctuation.bracket
-  <<3:8>>
-  //^ number
-  // ^ punctuation.delimiter
-  //  ^ number
-  <<3:size(8)>>
-  //^ number
-  // ^ punctuation.delimiter
-  //   ^ function.builtin
-  //      ^ punctuation.bracket
-  //       ^ number
-  //        ^ punctuation.bracket
-  <<code:int-size(8)-unit(2), reason:utf8>>
-  // ^ variable
-  //      ^ function.builtin
-  //        ^ punctuation.delimiter
-  //          ^ function.builtin
-  //              ^ number
-  //                  ^ function.builtin
-  //                      ^ number
-  //                             ^ variable
-  //                                   ^ function.builtin
-}
+<<3>>
+// <- punctuation.bracket
+//^ number
+// ^ punctuation.bracket
+<<3:8>>
+//^ number
+// ^ punctuation.delimiter
+//  ^ number
+<<3:size(8)>>
+//^ number
+// ^ punctuation.delimiter
+//   ^ function.builtin
+//      ^ punctuation.bracket
+//       ^ number
+//        ^ punctuation.bracket
+<<code:int-size(8)-unit(2), reason:utf8>>
+// ^ variable
+//      ^ function.builtin
+//        ^ punctuation.delimiter
+//          ^ function.builtin
+//              ^ number
+//                  ^ function.builtin
+//                      ^ number
+//                             ^ variable
+//                                   ^ function.builtin


### PR DESCRIPTION
This PR is actually more of a question than a solution 😅

Parsing expressions in the top-level (under source_file, outside of functions where they would normally be parsed) is advantageous when injecting Gleam, as you might do with markdown. This is pertinent to #14 because as far as I know, GitHub uses the tree-sitter parser for markdown's fenced code blocks. For example in #19, I have a code block

    ```gleam
    <<code:int-size(8)-unit(2), reason:utf8>>
    ```

Which is not a valid gleam program but is a valid gleam "snippet" so to speak.

What would you think about allowing expressions in the top-level like this?

(I didn't really look at those changed import tests yet, looks like some error nodes made their way into the tests and this PR ends up changing the error behavior.)
