### PR TITLE
use `function` node as a locals scope rather than `function_body`

### DIFF
--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,5 +1,5 @@
 ; Scopes
-(function_body) @local.scope
+(function) @local.scope
 
 (case_clause) @local.scope
 

--- a/test/highlight/functions.gleam
+++ b/test/highlight/functions.gleam
@@ -68,6 +68,13 @@ fn trial(uri) {
   }
 }
 
+fn my_uri_to_string(my_uri) -> String {
+  uri.to_string(my_uri)
+  // <- module
+  //   ^ function
+  //             ^ variable.parameter
+}
+
 fn myfun(argument) {
   let local_fun = fn(x) { x + 1 }
   //   ^ variable


### PR DESCRIPTION
closes #25

Parameters live outside of the `function_body`, so if you have a function parameter that matches a module name, it will highlight the module as a `@variable.parameter` for the rest of the document instead of just the body of the function. As a fix we can set `function` as a scope instead, so function names, parameters, and body all live under one scope.