### PR TITLE
Change constructor tracking to not use type

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -32,10 +32,10 @@
 (type_definition
   (data_constructors
     (data_constructor
-      name: (constructor_name) @name))) @definition.type
+      name: (constructor_name) @name))) @definition.constructor
 (external_type
   (type_name
     name: (type_identifier) @name)) @definition.type
 
 (type_identifier) @name @reference.type
-(constructor_name) @name @reference.type
+(constructor_name) @name @reference.constructor

--- a/test/tags/frame.gleam
+++ b/test/tags/frame.gleam
@@ -9,14 +9,14 @@ import gleam/bit_builder
 pub type FrameData {
   //      ^ definition.type
   Text(String)
-  // <- definition.type
+  // <- definition.constructor
   //    ^ reference.type
   Binary(BitString)
   Continuation(BitString)
   Ping(BitString)
   Pong(BitString)
   Close(code: Option(Int), reason: Option(String))
-  // <- definition.type
+  // <- definition.constructor
   //            ^ reference.type
   //                  ^ reference.type
   //                                ^ reference.type
@@ -42,7 +42,7 @@ fn encode_frame(frame: Frame) -> bit_builder.BitBuilder {
   let opcode =
     case frame.data {
       Continuation(_) -> <<0x0:size(1)>>
-      // <- reference.type
+      // <- reference.constructor
       Text(_) -> <<0x1:size(1)>>
       Binary(_) -> <<0x2:size(1)>>
       // 0x3-7 reserved for future non-control frames

--- a/test/tags/functions.gleam
+++ b/test/tags/functions.gleam
@@ -1,6 +1,6 @@
 fn record_with_fun_field(record) {
   let foo = Bar(baz: fn(x) { x + 1 })
-  //         ^ reference.type
+  //         ^ reference.constructor
   foo.baz(41)
   record.foobar("hello")
 


### PR DESCRIPTION
For the tags queries, it seemed odd that we were using `definition.type` and `reference.type` for tracking constructors. However, none of the [standard set of capture names](https://tree-sitter.github.io/tree-sitter/code-navigation-systems#examples) seem applicable (maybe `class`?), so I made up `constructor` and hope that most systems don't hardcode the standard set.