### PR TITLE
add integration test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  bless:
+  test:
     name: Test
     runs-on: ubuntu-latest
 
@@ -35,3 +35,33 @@ jobs:
 
       - name: Check formatting
         run: npm run check-formatted
+
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Ensure generated parser files are up to date
+        run: npx tree-sitter generate
+
+      - name: Run integration tests
+        run: ./scripts/integration_test.sh

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -1,0 +1,24 @@
+#! /usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+usage() {
+  echo "$0"
+  echo ""
+  echo "Tests that the parser does not create error nodes"
+  echo "when tested against real Gleam repos"
+  echo ""
+  exit 1
+}
+
+if [ $# -ne 0 ]; then
+  usage
+fi
+
+repos="gleam-lang/stdlib gleam-lang/json gleam-lang/http gleam-lang/example-todomvc gleam-lang/bitwise gleam-lang/erlang gleam-lang/otp gleam-lang/cowboy gleam-lang/hackney gleam-lang/httpc gleam-lang/elli gleam-lang/javascript gleam-lang/example-echo-server gleam-lang/plug"
+
+for repo in $repos; do
+  ./scripts/parse_repo.sh $repo
+done

--- a/scripts/parse_repo.sh
+++ b/scripts/parse_repo.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+usage() {
+  echo "$0 owner/repository"
+  echo ""
+  echo "Runs the parser against Gleam files in a GitHub repository"
+  echo ""
+  exit 1
+}
+
+if [ $# -ne 1 ]; then
+  usage
+fi
+
+gh_repo="$1"
+dir="test/integration/${gh_repo//[\/-]/_}"
+
+if [[ ! -d "$dir" ]]; then
+  mkdir -p "$(dirname "$dir")"
+  git clone --depth 1 "https://github.com/$gh_repo.git" "$dir"
+fi
+
+echo "Running parser against $gh_repo"
+
+npx tree-sitter parse --quiet --stat "$dir/**/*.gleam"

--- a/test/integration/.gitignore
+++ b/test/integration/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Tree-sitter-elixir has a [similar mechanism](https://github.com/elixir-lang/tree-sitter-elixir/blob/5d0c1bfcdf8aaad225525acad930a972b319a675/scripts/integration_test.sh) for testing against real elixir repos. That shell script is run in tree-sitter-elixir's test CI.

This just tests the stdlib and should be passing after #31. We could expand this to run against more repos with gleam source in them. It might also be a good idea to run this on a cron instead of along with the test CI. What do you think?