### PR TITLE
Ensure external_scanner_scan returns false for unrecognized tokens

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -25,4 +25,5 @@ bool tree_sitter_gleam_external_scanner_scan(void * payload, TSLexer *lexer, con
     lexer->result_symbol = QUOTED_CONTENT;
     return has_content;
   }
+  return false;
 }


### PR DESCRIPTION
I noticed that clang++ warned here: 
```
deps/tree-sitter-gleam/src/scanner.c:28:1: warning: non-void function does not return a value in all control paths
```

An explicit return fixes things up.