### PR TITLE
Reclassify let/use as statements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -229,7 +229,7 @@ module.exports = grammar({
         field("parameters", $.function_parameters),
         optional(seq("->", field("return_type", $._type))),
         "{",
-        optional(field("body", alias($._expression_seq, $.function_body))),
+        optional(field("body", alias($._statement_seq, $.function_body))),
         "}"
       ),
     function_parameters: ($) =>
@@ -271,7 +271,7 @@ module.exports = grammar({
     // This makes sense for the parser, but (IMO) would be more confusing for
     // users and tooling which don't think about `try`s as having a "then". Thus,
     // `try`s are essentially treated the same as any other expression.
-    _expression_seq: ($) => repeat1(choice($._expression, $.try)),
+    _statement_seq: ($) => repeat1(choice($._statement, $.try)),
     try: ($) =>
       seq(
         "try",
@@ -280,6 +280,7 @@ module.exports = grammar({
         "=",
         field("value", $._expression)
       ),
+    _statement: ($) => choice($._expression, $.let, $.use),
     _expression: ($) => choice($._expression_unit, $.binary_expression),
     binary_expression: ($) =>
       choice(
@@ -333,8 +334,6 @@ module.exports = grammar({
         $.expression_group,
         $.case,
         $.let_assert,
-        $.let,
-        $.use,
         $.assert,
         $.negation,
         $.record_update,
@@ -374,7 +373,7 @@ module.exports = grammar({
         ),
         optional(seq("->", field("return_type", $._type))),
         "{",
-        field("body", alias($._expression_seq, $.function_body)),
+        field("body", alias($._statement_seq, $.function_body)),
         "}"
       ),
     anonymous_function_parameters: ($) =>
@@ -393,7 +392,7 @@ module.exports = grammar({
         choice($._discard_param, $._name_param),
         optional($._type_annotation)
       ),
-    expression_group: ($) => seq("{", $._expression_seq, "}"),
+    expression_group: ($) => seq("{", $._statement_seq, "}"),
     case: ($) =>
       seq(
         "case",

--- a/grammar.js
+++ b/grammar.js
@@ -30,9 +30,9 @@ module.exports = grammar({
   rules: {
     /* General rules */
     source_file: ($) =>
-      repeat(choice($.target_group, $._statement, $._expression_seq)),
+      repeat(choice($.target_group, $._module_statement, $._statement_seq)),
 
-    _statement: ($) =>
+    _module_statement: ($) =>
       choice(
         $.import,
         $.constant,
@@ -50,7 +50,13 @@ module.exports = grammar({
 
     /* Target groups */
     target_group: ($) =>
-      seq("if", field("target", $.target), "{", repeat($._statement), "}"),
+      seq(
+        "if",
+        field("target", $.target),
+        "{",
+        repeat($._module_statement),
+        "}"
+      ),
     target: ($) => choice("erlang", "javascript"),
 
     /* Import statements */

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -482,7 +482,7 @@ fn field_access(x) {
           name: (constructor_name)
           arguments: (arguments
             (argument
-                value: (integer)))))
+              value: (integer)))))
       (let_assert
         pattern: (identifier)
         value: (expression_group


### PR DESCRIPTION
Closes #51

I also included a change to rename `_statement` which was introduced back in https://github.com/gleam-lang/tree-sitter-gleam/pull/20. It looks like this is now referred to as ModuleStatement in the compiler (see [here](https://github.com/gleam-lang/gleam/blob/ea51e5fd74a7c6bfe52d1f31de4339d00bdcf55c/compiler-core/src/ast.rs#L530-L544)).