### PR TITLE
support empty case clauses to prevent parsing error

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -398,7 +398,7 @@ module.exports = grammar({
         "case",
         field("subjects", $.case_subjects),
         "{",
-        field("clauses", $.case_clauses),
+        optional(field("clauses", $.case_clauses)),
         "}"
       ),
     case_subjects: ($) => seq(series_of($._expression, ",")),

--- a/test/corpus/cases.txt
+++ b/test/corpus/cases.txt
@@ -1,0 +1,34 @@
+================================================================================
+Case examples
+================================================================================
+
+case value {
+  "A" -> True
+  _ -> False
+}
+
+case value {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (case
+    (case_subjects
+      (identifier))
+    (case_clauses
+      (case_clause
+        (case_clause_patterns
+          (case_clause_pattern
+            (string
+              (quoted_content))))
+        (record
+          (constructor_name)))
+      (case_clause
+        (case_clause_patterns
+          (case_clause_pattern
+            (discard)))
+        (record
+          (constructor_name)))))
+  (case
+    (case_subjects
+      (identifier))))


### PR DESCRIPTION
The existing `case_clauses` requires at least one clause to parse correctly. This matches the gleam grammar, as it is required to be correct Gleam. This means, however, that indentation cannot be determined until at least some clause has been added. This is an annoyance when editing.

This PR address #57 by allowing empty case clauses. I confirmed that the existing indentation query in neovim functions as expected. Also added a test to handle both populated an un-populated case clauses. Not sure if this should just be included in an existing test case, happy to move it.