### PR TITLE
Make 'external' part of external type definitions optional

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -177,7 +177,15 @@ module.exports = grammar({
     constant_type_argument: ($) => $._constant_type,
 
     external_type: ($) =>
-      seq(optional($.visibility_modifier), "external", "type", $.type_name),
+      prec.right(
+        seq(
+          optional($.visibility_modifier),
+          // DEPRECATED: the external token was removed in v0.30.
+          optional("external"),
+          "type",
+          $.type_name
+        )
+      ),
 
     /* External function */
     external_function: ($) =>

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -74,6 +74,7 @@
   "assert"
   "case"
   "const"
+  ; DEPRECATED: 'external' was removed in v0.30.
   "external"
   "fn"
   "if"

--- a/test/corpus/external_types.txt
+++ b/test/corpus/external_types.txt
@@ -2,9 +2,9 @@
 External types
 ================================================================================
 
-external type IODevice
-external type IODevice()
-external type Map(key, value)
+type IODevice
+type IODevice()
+type Map(key, value)
 
 --------------------------------------------------------------------------------
 
@@ -27,9 +27,9 @@ external type Map(key, value)
 Public external types
 ================================================================================
 
-pub external type IODevice
-pub external type IODevice()
-pub external type Map(key, value)
+pub type IODevice
+pub type IODevice()
+pub type Map(key, value)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #61