### PR TITLE
Parse attribute syntax

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -35,7 +35,8 @@ module.exports = grammar({
         $.external_function,
         $.function,
         $.type_definition,
-        $.type_alias
+        $.type_alias,
+        $.attribute
       ),
 
     /* Comments */
@@ -43,7 +44,9 @@ module.exports = grammar({
     statement_comment: ($) => token(seq("///", /.*/)),
     comment: ($) => token(seq("//", /.*/)),
 
-    /* Target groups */
+    /* Target groups
+     * DEPRECATED: This syntax was replaced with attributes in v0.30.
+     */
     target_group: ($) =>
       seq(
         "if",
@@ -53,6 +56,23 @@ module.exports = grammar({
         "}"
       ),
     target: ($) => choice("erlang", "javascript"),
+
+    /* Attributes */
+    attribute: ($) =>
+      seq(
+        "@",
+        field("name", $.identifier),
+        field("arguments", alias($._attribute_arguments, $.arguments))
+      ),
+
+    _attribute_arguments: ($) =>
+      seq("(", series_of($.attribute_value, ","), ")"),
+
+    attribute_value: ($) =>
+      choice(
+        $._constant_value,
+        seq(field("label", $.label), ":", field("value", $._constant_value))
+      ),
 
     /* Import statements */
     import: ($) =>

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -43,6 +43,13 @@
 (tuple_access
   index: (integer) @property)
 
+; Attributes
+(attribute
+  "@" @attribute
+  name: (identifier) @attribute)
+
+(attribute_value (identifier) @constant)
+
 ; Type names
 (remote_type_identifier) @type
 (type_identifier) @type

--- a/test/corpus/attributes.txt
+++ b/test/corpus/attributes.txt
@@ -1,0 +1,48 @@
+================================================================================
+Target attribute
+================================================================================
+
+@target(erlang)
+pub fn main() { todo }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (attribute
+    name: (identifier)
+    arguments: (arguments
+      (attribute_value
+        (identifier))))
+  (function
+    (visibility_modifier)
+    name: (identifier)
+    parameters: (function_parameters)
+    body: (function_body
+      (todo))))
+
+================================================================================
+Attribute with multiple values
+================================================================================
+
+@deprecated(since: "1.2.0", replacement: wobble)
+pub fn wibble() { todo }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (attribute
+    name: (identifier)
+    arguments: (arguments
+      (attribute_value
+        label: (label)
+        value: (string
+          (quoted_content)))
+      (attribute_value
+        label: (label)
+        value: (identifier))))
+  (function
+    (visibility_modifier)
+    name: (identifier)
+    parameters: (function_parameters)
+    body: (function_body
+      (todo))))

--- a/test/highlight/modules.gleam
+++ b/test/highlight/modules.gleam
@@ -48,3 +48,27 @@ fn make_cat() -> kitty.Cat {
   // ^ module
   //    ^ constructor
 }
+
+@target(erlang)
+// <- attribute
+// ^ attribute
+//        ^ constant
+pub external fn display() -> Bool = "erlang" "display"
+
+@target(erlang)
+@external(erlang, "wobble", "main")
+// <- attribute
+// ^ attribute
+//         ^ constant
+//                   ^ string
+//                            string
+pub fn main() -> Int
+
+@deprecated(since: "1.2.0", replacement: wobble)
+// <- attribute
+// ^ attribute
+//           ^ property
+//                  ^ string
+//                            ^ property
+//                                        ^constant
+pub fn wibble() { todo }


### PR DESCRIPTION
Closes #60.

I didn't add a requirement that attributes preceed imports or functions but I think it's probably ok if we're a little more permissive about that. I'm happy to add some extra checks if that's desired though.