### PR TITLE
Allow function bodies to be optional

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -245,15 +245,21 @@ module.exports = grammar({
 
     /* Functions */
     function: ($) =>
-      seq(
-        optional($.visibility_modifier),
-        "fn",
-        field("name", $.identifier),
-        field("parameters", $.function_parameters),
-        optional(seq("->", field("return_type", $._type))),
-        "{",
-        optional(field("body", alias($._statement_seq, $.function_body))),
-        "}"
+      prec.right(
+        seq(
+          optional($.visibility_modifier),
+          "fn",
+          field("name", $.identifier),
+          field("parameters", $.function_parameters),
+          optional(seq("->", field("return_type", $._type))),
+          optional(
+            seq(
+              "{",
+              optional(field("body", alias($._statement_seq, $.function_body))),
+              "}"
+            )
+          )
+        )
       ),
     function_parameters: ($) =>
       seq("(", optional(series_of($.function_parameter, ",")), ")"),

--- a/test/corpus/external_functions.txt
+++ b/test/corpus/external_functions.txt
@@ -136,3 +136,40 @@ pub external fn a() -> #(List(Int), fn(Int) -> String) = "x" "y"
         (quoted_content))
       (string
         (quoted_content)))))
+
+================================================================================
+External function with attribute syntax
+================================================================================
+
+@external(erlang, "erlang", "integer_to_list")
+fn integer_to_list(int int: Int, base base: Int) -> String
+
+---
+
+(source_file
+  (attribute
+    (identifier)
+    (arguments
+      (attribute_value
+        (identifier))
+      (attribute_value
+        (string
+          (quoted_content)))
+      (attribute_value
+        (string
+          (quoted_content)))))
+  (function
+    (identifier)
+    (function_parameters
+      (function_parameter
+        (label)
+        (identifier)
+        (type
+          (type_identifier)))
+      (function_parameter
+        (label)
+        (identifier)
+        (type
+          (type_identifier))))
+    (type
+      (type_identifier))))


### PR DESCRIPTION
Closes #67

Ideally we would only allow this after attributes but that would complicate the grammar. I think it's ok to be a little more permissive here and allow functions to not have bodies - it will also provide slightly better highlighting as-you-type.