### PR TITLE
Remove support for 'try' from the parser

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -278,36 +278,7 @@ module.exports = grammar({
     _labeled_name_param: ($) =>
       seq(field("label", $.label), field("name", $.identifier)),
     _name_param: ($) => field("name", $.identifier),
-    // This method diverges from the parser's `parse_expression_seq` somewhat.
-    // The parser considers all expressions after a `try` to be part of its AST
-    // node, namely the "then" section. Gleam code like this:
-    //
-    //    try int_a = parse(a)
-    //    try int_b = parse(b)
-    //    Ok(int_a + int_b)
-    //
-    // is parsed as:
-    //
-    // (try
-    //   pattern: (pattern)
-    //   value: (call (identifier))
-    //   then: (try
-    //     pattern: (pattern)
-    //     value: (call (identifier))
-    //     then: (record (...))))
-    //
-    // This makes sense for the parser, but (IMO) would be more confusing for
-    // users and tooling which don't think about `try`s as having a "then". Thus,
-    // `try`s are essentially treated the same as any other expression.
-    _statement_seq: ($) => repeat1(choice($._statement, $.try)),
-    try: ($) =>
-      seq(
-        "try",
-        field("pattern", $._pattern),
-        optional($._type_annotation),
-        "=",
-        field("value", $._expression)
-      ),
+    _statement_seq: ($) => repeat1($._statement),
     _statement: ($) => choice($._expression, $.let, $.let_assert, $.use),
     _expression: ($) => choice($._expression_unit, $.binary_expression),
     binary_expression: ($) =>


### PR DESCRIPTION
This was 'soft-removed' in the past by removing the highlights and test cases but we held off on fully removing the parser support. This finishes the job so that 'try' is no longer treated as a keyword. This should fix the integration tests. Previously they would fail against some code in the stdlib which used 'try' as a regular variable name.

What do you think @J3RN? I think we were keeping this around for backwards compatibility but it's been a few minor releases since it was removed (this change would target 0.32.0). I think it'd be nice to fully remove it so the integration tests are passing again.