### PR TITLE
Allow discarding module imports with underscore

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -80,7 +80,7 @@ module.exports = grammar({
         "import",
         field("module", $.module),
         optional(seq(".", field("imports", $.unqualified_imports))),
-        optional(seq("as", field("alias", $.identifier)))
+        optional(seq("as", field("alias", choice($.identifier, $.discard))))
       ),
     module: ($) => seq($._name, repeat(seq("/", $._name))),
     unqualified_imports: ($) =>

--- a/test/corpus/imports.txt
+++ b/test/corpus/imports.txt
@@ -108,3 +108,19 @@ import animal.{type Cat as Kitty}
       (unqualified_import
         name: (type_identifier)
         alias: (type_identifier)))))
+
+================================================================================
+Discard module imports
+================================================================================
+
+import wibble.{wobble} as _
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (import
+    (module)
+    (unqualified_imports
+      (unqualified_import
+        (identifier)))
+    (discard)))

--- a/test/highlight/modules.gleam
+++ b/test/highlight/modules.gleam
@@ -11,6 +11,11 @@ import animal/cat.{Cat, type Cat}
 //                        ^ keyword
 //                            ^ type
 
+import wibble.{wobble} as _
+//      ^ module
+//              ^ function
+//                        ^ comment.unused
+
 pub fn main() {
   io.println("hello world")
   // <- module


### PR DESCRIPTION
Gleam 0.23.3 allows discarding imported modules with the discard syntax. This needs a small change in tree-sitter-gleam to accept discard nodes in the import's 'as' field.