### PR TITLE
Parse unicode escape sequences in strings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -677,7 +677,11 @@ module.exports = grammar({
         repeat(choice($.escape_sequence, $.quoted_content)),
         token.immediate('"')
       ),
-    escape_sequence: ($) => token.immediate(/\\[efnrt\"\\]/),
+    escape_sequence: ($) =>
+      choice(
+        token.immediate(/\\[efnrt\"\\]/),
+        token.immediate(/\\u\{[0-9a-fA-F]{1,6}\}/)
+      ),
     float: ($) => /-?[0-9_]+\.[0-9_]*(e-?[0-9_]+)?/,
     integer: ($) =>
       seq(optional("-"), choice($._hex, $._decimal, $._octal, $._binary)),

--- a/test/corpus/strings.txt
+++ b/test/corpus/strings.txt
@@ -6,6 +6,8 @@ Escape sequences
 "¯\\_(ツ)_/¯"
 "\"\""
 "Hello, \e\f"
+// 🏴‍☠️ is 🏴 and ☠️  joined with a zero-width joiner (U+200D)
+"🏴‍☠️ == \u{1F3F4}\u{200D}\u{2620}\u{FE0F}"
 
 --------------------------------------------------------------------------------
 
@@ -25,5 +27,12 @@ Escape sequences
     (escape_sequence))
   (string
     (quoted_content)
+    (escape_sequence)
+    (escape_sequence))
+  (comment)
+  (string
+    (quoted_content)
+    (escape_sequence)
+    (escape_sequence)
     (escape_sequence)
     (escape_sequence)))


### PR DESCRIPTION
In v0.33.0, strings can use escapes like `\u{200D}` to escape in arbitrary unicode codepoints.