### PR TITLE
support attributes without arguments (i.e. `@internal`)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -62,7 +62,7 @@ module.exports = grammar({
       seq(
         "@",
         field("name", $.identifier),
-        field("arguments", alias($._attribute_arguments, $.arguments))
+        optional(field("arguments", alias($._attribute_arguments, $.arguments)))
       ),
 
     _attribute_arguments: ($) =>

--- a/test/corpus/attributes.txt
+++ b/test/corpus/attributes.txt
@@ -46,3 +46,22 @@ pub fn wibble() { todo }
     parameters: (function_parameters)
     body: (function_body
       (todo))))
+
+================================================================================
+Attribute without arguments
+================================================================================
+
+@internal
+pub fn wibble() { todo }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (attribute
+    name: (identifier))
+  (function
+    (visibility_modifier)
+    name: (identifier)
+    parameters: (function_parameters)
+    body: (function_body
+      (todo))))


### PR DESCRIPTION
As far as I can tell, this is the correct syntax for `@internal`.