### PR TITLE
Highlight echo

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -21,6 +21,8 @@ module.exports = grammar({
     [$.source_file],
     [$._constant_value, $._case_clause_guard_unit],
     [$.integer],
+    [$.pipeline_echo, $.echo],
+    [$.echo],
   ],
   rules: {
     /* General rules */
@@ -298,7 +300,13 @@ module.exports = grammar({
         binaryExpr(prec.left, 4, ">=", $._expression),
         binaryExpr(prec.left, 4, ">.", $._expression),
         binaryExpr(prec.left, 4, ">=.", $._expression),
-        binaryExpr(prec.left, 5, "|>", $._expression),
+        binaryExpr(
+          prec.left,
+          5,
+          "|>",
+          $._expression,
+          choice($.pipeline_echo, $._expression)
+        ),
         binaryExpr(prec.left, 6, "+", $._expression),
         binaryExpr(prec.left, 6, "+.", $._expression),
         binaryExpr(prec.left, 6, "-", $._expression),
@@ -330,6 +338,7 @@ module.exports = grammar({
         $.todo,
         $.panic,
         $.tuple,
+        $.echo,
         $.list,
         alias($._expression_bit_string, $.bit_string),
         $.anonymous_function,
@@ -369,6 +378,8 @@ module.exports = grammar({
           )
         )
       ),
+    pipeline_echo: (_$) => " echo",
+    echo: ($) => seq("echo", $._expression),
     tuple: ($) => seq("#", "(", optional(series_of($._expression, ",")), ")"),
     list: ($) =>
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -21,7 +21,6 @@ module.exports = grammar({
     [$.source_file],
     [$._constant_value, $._case_clause_guard_unit],
     [$.integer],
-    [$.pipeline_echo, $.echo],
     [$.echo],
   ],
   rules: {
@@ -378,7 +377,7 @@ module.exports = grammar({
           )
         )
       ),
-    pipeline_echo: (_$) => " echo",
+    pipeline_echo: (_$) => prec.left("echo"),
     echo: ($) => seq("echo", $._expression),
     tuple: ($) => seq("#", "(", optional(series_of($._expression, ",")), ")"),
     list: ($) =>

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -73,7 +73,7 @@
 ; TODO: when tree-sitter supports `#any-of?` in the Rust bindings,
 ; refactor this to use `#any-of?` rather than `#match?`
 ((identifier) @error
- (#match? @error "^(auto|delegate|derive|else|implement|macro|test|echo)$"))
+ (#match? @error "^(auto|delegate|derive|else|implement|macro|test)$"))
 
 ; Variables
 (identifier) @variable
@@ -87,6 +87,7 @@
   "assert"
   "case"
   "const"
+  "echo"
   ; DEPRECATED: 'external' was removed in v0.30.
   "external"
   "fn"

--- a/test/corpus/echo.txt
+++ b/test/corpus/echo.txt
@@ -64,3 +64,49 @@ pub fn main() {
         (list)
         (pipeline_echo))
       (integer))))
+
+================================================================================
+Echo precedence with pipes
+================================================================================
+
+pub fn main() {
+  echo 1 |> 2
+  3
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function
+    (visibility_modifier)
+    (identifier)
+    (function_parameters)
+    (function_body
+      (echo
+        (binary_expression
+          (integer)
+          (integer)))
+      (integer))))
+
+================================================================================
+Echo precedence with binop
+================================================================================
+
+pub fn main() {
+  echo 1 + 2
+  3
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function
+    (visibility_modifier)
+    (identifier)
+    (function_parameters)
+    (function_body
+      (echo
+        (binary_expression
+          (integer)
+          (integer)))
+      (integer))))

--- a/test/corpus/echo.txt
+++ b/test/corpus/echo.txt
@@ -1,0 +1,66 @@
+================================================================================
+Echo with expression
+================================================================================
+
+pub fn main() {
+  echo 1
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function
+    (visibility_modifier)
+    (identifier)
+    (function_parameters)
+    (function_body
+      (echo
+        (integer)))))
+
+================================================================================
+Echo in pipeline
+================================================================================
+
+pub fn main() {
+  []
+  |> echo
+  |> panic
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function
+    (visibility_modifier)
+    (identifier)
+    (function_parameters)
+    (function_body
+      (binary_expression
+        (binary_expression
+          (list)
+          (pipeline_echo))
+        (panic)))))
+
+================================================================================
+Echo last in pipeline
+================================================================================
+
+pub fn main() {
+  []
+  |> echo
+
+  1
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function
+    (visibility_modifier)
+    (identifier)
+    (function_parameters)
+    (function_body
+      (binary_expression
+        (list)
+        (pipeline_echo))
+      (integer))))

--- a/test/highlight/reserved.gleam
+++ b/test/highlight/reserved.gleam
@@ -12,5 +12,3 @@ macro
 // <- error
 test
 // <- error
-echo
-// <- error


### PR DESCRIPTION
This PR adds syntax highlight for the `echo` keyword. I'm having a problem with a test failing:
```txt
syntax highlighting:
  ✗ functions.gleam
    Failure - row: 86, column: 5, expected highlight 'variable', actual highlights: 'function'
```
I can't really understand why is that, it looks unrelated to the `echo` addition. By playing around it look like that it's that `$.pipeline_echo` I've added in the `|>` operator that's messing things up but I know too little about tree sitter to figure this out on my own