### PR TITLE
fix(functions): remove function body alias and use block

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -255,13 +255,7 @@ module.exports = grammar({
           field("name", $.identifier),
           field("parameters", $.function_parameters),
           optional(seq("->", field("return_type", $._type))),
-          optional(
-            seq(
-              "{",
-              optional(field("body", alias($._statement_seq, $.function_body))),
-              "}"
-            )
-          )
+          optional(field("body", $.block))
         )
       ),
     function_parameters: ($) =>
@@ -406,9 +400,7 @@ module.exports = grammar({
           alias($.anonymous_function_parameters, $.function_parameters)
         ),
         optional(seq("->", field("return_type", $._type))),
-        "{",
-        field("body", alias($._statement_seq, $.function_body)),
-        "}"
+        field("body", $.block)
       ),
     anonymous_function_parameters: ($) =>
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -418,7 +418,7 @@ module.exports = grammar({
         choice($._discard_param, $._name_param),
         optional($._type_annotation)
       ),
-    block: ($) => seq("{", $._statement_seq, "}"),
+    block: ($) => seq("{", optional($._statement_seq), "}"),
     case: ($) =>
       seq(
         "case",

--- a/test/corpus/attributes.txt
+++ b/test/corpus/attributes.txt
@@ -17,7 +17,7 @@ pub fn main() { todo }
     (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (todo))))
 
 ================================================================================
@@ -44,7 +44,7 @@ pub fn wibble() { todo }
     (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (todo))))
 
 ================================================================================
@@ -63,5 +63,5 @@ pub fn wibble() { todo }
     (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (todo))))

--- a/test/corpus/cases.txt
+++ b/test/corpus/cases.txt
@@ -68,7 +68,7 @@ pub fn listed(names: List(String), person: Person) -> String {
           (type_identifier))))
     (type
       (type_identifier))
-    (function_body
+    (block
       (case
         (case_subjects
           (identifier))

--- a/test/corpus/destructuring.txt
+++ b/test/corpus/destructuring.txt
@@ -16,7 +16,7 @@ pub fn main() {
     (visibility_modifier)
     (identifier)
     (function_parameters)
-    (function_body
+    (block
       (case
         (case_subjects
           (identifier))
@@ -64,7 +64,7 @@ pub fn main() {
     (visibility_modifier)
     (identifier)
     (function_parameters)
-    (function_body
+    (block
       (let
         (record_pattern
           (constructor_name)

--- a/test/corpus/echo.txt
+++ b/test/corpus/echo.txt
@@ -13,7 +13,7 @@ pub fn main() {
     (visibility_modifier)
     (identifier)
     (function_parameters)
-    (function_body
+    (block
       (echo
         (integer)))))
 
@@ -34,7 +34,7 @@ pub fn main() {
     (visibility_modifier)
     (identifier)
     (function_parameters)
-    (function_body
+    (block
       (binary_expression
         (binary_expression
           (list)
@@ -59,7 +59,7 @@ pub fn main() {
     (visibility_modifier)
     (identifier)
     (function_parameters)
-    (function_body
+    (block
       (binary_expression
         (list)
         (pipeline_echo))
@@ -81,7 +81,7 @@ pub fn main() {
     (visibility_modifier)
     (identifier)
     (function_parameters)
-    (function_body
+    (block
       (echo
         (binary_expression
           (integer)
@@ -104,7 +104,7 @@ pub fn main() {
     (visibility_modifier)
     (identifier)
     (function_parameters)
-    (function_body
+    (block
       (echo
         (binary_expression
           (integer)

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -314,9 +314,7 @@ fn field_access(x) {
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (block
-      (todo
-        (MISSING "todo"))))
+    body: (block))
   (function
     name: (identifier)
     parameters: (function_parameters)

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -35,7 +35,7 @@ fn replace(
           name: (type_identifier))))
     return_type: (type
       name: (type_identifier))
-    body: (function_body
+    body: (block
       (binary_expression
         left: (identifier)
         right: (identifier))))
@@ -52,7 +52,7 @@ fn replace(
         name: (identifier)
         type: (type_var)))
     return_type: (type_var)
-    body: (function_body
+    body: (block
       (function_call
         function: (identifier)
         arguments: (arguments
@@ -67,7 +67,7 @@ fn replace(
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (identifier)))
   (function
     name: (identifier)
@@ -87,7 +87,7 @@ fn replace(
         name: (identifier)
         type: (type
           name: (type_identifier))))
-    body: (function_body
+    body: (block
       (function_call
         function: (field_access
           record: (identifier)
@@ -141,7 +141,7 @@ pub fn replace(
           name: (type_identifier))))
     return_type: (type
       name: (type_identifier))
-    body: (function_body
+    body: (block
       (binary_expression
         left: (identifier)
         right: (identifier))))
@@ -159,7 +159,7 @@ pub fn replace(
         name: (identifier)
         type: (type_var)))
     return_type: (type_var)
-    body: (function_body
+    body: (block
       (function_call
         function: (identifier)
         arguments: (arguments
@@ -175,7 +175,7 @@ pub fn replace(
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (identifier)))
   (function
     (visibility_modifier)
@@ -196,7 +196,7 @@ pub fn replace(
         name: (identifier)
         type: (type
           name: (type_identifier))))
-    body: (function_body
+    body: (block
       (function_call
         function: (field_access
           record: (identifier)
@@ -313,27 +313,30 @@ fn field_access(x) {
 (source_file
   (function
     name: (identifier)
-    parameters: (function_parameters))
+    parameters: (function_parameters)
+    body: (block
+      (todo
+        (MISSING "todo"))))
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (string
         (quoted_content))))
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (integer)))
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (float)))
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (record
         name: (constructor_name)
         arguments: (arguments
@@ -344,7 +347,7 @@ fn field_access(x) {
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (record
         name: (remote_constructor_name
           module: (identifier)
@@ -359,26 +362,26 @@ fn field_access(x) {
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (identifier)))
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (function_call
         function: (identifier)
         arguments: (arguments))))
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (todo
         message: (string
           (quoted_content)))))
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (panic)
       (panic
         message: (string
@@ -388,7 +391,7 @@ fn field_access(x) {
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (tuple
         (identifier)
         (integer))))
@@ -397,7 +400,7 @@ fn field_access(x) {
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (list
         (integer)
         (integer)
@@ -405,7 +408,7 @@ fn field_access(x) {
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (bit_string
         (bit_string_segment
           value: (integer)
@@ -424,21 +427,21 @@ fn field_access(x) {
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (anonymous_function
         parameters: (function_parameters
           (function_parameter
             name: (identifier)
             type: (type
               name: (type_identifier))))
-        body: (function_body
+        body: (block
           (binary_expression
             left: (identifier)
             right: (identifier))))))
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (block
         (binary_expression
           left: (integer)
@@ -452,7 +455,7 @@ fn field_access(x) {
         name: (identifier))
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (case
         subjects: (case_subjects
           (identifier)
@@ -477,7 +480,7 @@ fn field_access(x) {
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (let_assert
         pattern: (record_pattern
           name: (constructor_name)
@@ -532,7 +535,7 @@ fn field_access(x) {
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (let
         pattern: (identifier)
         value: (block
@@ -554,7 +557,7 @@ fn field_access(x) {
   (function
     name: (identifier)
     parameters: (function_parameters)
-    body: (function_body
+    body: (block
       (assert
         pattern: (record_pattern
           name: (constructor_name)
@@ -589,7 +592,7 @@ fn field_access(x) {
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (record_update
         constructor: (constructor_name)
         spread: (identifier)
@@ -623,7 +626,7 @@ fn field_access(x) {
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (tuple_access
         tuple: (identifier)
         index: (integer))))
@@ -632,7 +635,7 @@ fn field_access(x) {
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (field_access
         record: (identifier)
         field: (label)))))
@@ -676,7 +679,7 @@ fn trial(x, y, z) {
         name: (identifier))
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (case
         subjects: (case_subjects
           (identifier))
@@ -812,7 +815,7 @@ let fun_ref = float.to_string
       parameters: (function_parameters
         (function_parameter
           name: (identifier)))
-      body: (function_body
+      body: (block
         (identifier))))
   (let
     pattern: (identifier)
@@ -838,7 +841,7 @@ fn complicated(x, y) {
         name: (identifier))
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (binary_expression
         left: (binary_expression
           left: (binary_expression
@@ -882,7 +885,7 @@ fn complex_data_fun(x, y) {
         name: (identifier))
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (field_access
         record: (tuple_access
           tuple: (field_access
@@ -950,7 +953,7 @@ fn weird(x) {
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (function_call
         function: (identifier)
         arguments: (arguments
@@ -963,7 +966,7 @@ fn weird(x) {
           parameters: (function_parameters
             (function_parameter
               name: (identifier)))
-          body: (function_body
+          body: (block
             (binary_expression
               left: (identifier)
               right: (integer))))
@@ -978,7 +981,7 @@ fn weird(x) {
               parameters: (function_parameters
                 (function_parameter
                   name: (identifier)))
-              body: (function_body
+              body: (block
                 (binary_expression
                   left: (identifier)
                   right: (integer))))))
@@ -998,7 +1001,7 @@ fn weird(x) {
                 parameters: (function_parameters
                   (function_parameter
                     name: (identifier)))
-                body: (function_body
+                body: (block
                   (binary_expression
                     left: (identifier)
                     right: (integer)))))))
@@ -1034,7 +1037,7 @@ fn ignores(foo, _bar) {
         name: (identifier))
       (function_parameter
         name: (discard)))
-    body: (function_body
+    body: (block
       (let
         pattern: (discard)
         value: (integer))
@@ -1065,7 +1068,7 @@ fn lists(x) {
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
-    body: (function_body
+    body: (block
       (list)
       (list
         (integer))

--- a/test/corpus/whole_files.txt
+++ b/test/corpus/whole_files.txt
@@ -48,7 +48,7 @@ if javascript {
           name: (type_identifier))))
     return_type: (type
       name: (type_identifier))
-    body: (function_body
+    body: (block
       (let
         pattern: (identifier)
         value: (function_call
@@ -184,7 +184,7 @@ pub fn negate(bool: Bool) -> Bool {
           name: (type_identifier))))
     return_type: (type
       name: (type_identifier))
-    body: (function_body
+    body: (block
       (case
         subjects: (case_subjects
           (identifier))
@@ -290,7 +290,7 @@ fn foo(a,) {
     (function_parameters
       (function_parameter
         (identifier)))
-    (function_body
+    (block
       (function_call
         (identifier)
         (arguments


### PR DESCRIPTION
This closes #110

Let me know if I misunderstood what you meant about the alias.  The test updates make sense to me, though I don't fully understand the `(MISSING "todo")` part 😅.  It seems to work as expected in neovim, anyway.