### PR TITLE
Use constructor names for unqualified imported values

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -93,9 +93,13 @@ module.exports = grammar({
           optional(seq("as", field("alias", $.identifier)))
         ),
         seq(
-          optional("type"),
+          "type",
           field("name", $.type_identifier),
           optional(seq("as", field("alias", $.type_identifier)))
+        ),
+        seq(
+          field("name", $.constructor_name),
+          optional(seq("as", field("alias", $.constructor_name)))
         )
       ),
 

--- a/test/corpus/imports.txt
+++ b/test/corpus/imports.txt
@@ -21,6 +21,7 @@ import a.{b}
 import a/b.{c, d}
 import a/b.{c as d, e}
 import a/b.{c, D as E}
+import a/b.{A as B, type C as D}
 
 --------------------------------------------------------------------------------
 
@@ -51,6 +52,15 @@ import a/b.{c, D as E}
       (unqualified_import
         name: (identifier))
       (unqualified_import
+        name: (constructor_name)
+        alias: (constructor_name))))
+  (import
+    module: (module)
+    imports: (unqualified_imports
+      (unqualified_import
+        name: (constructor_name)
+        alias: (constructor_name))
+      (unqualified_import
         name: (type_identifier)
         alias: (type_identifier)))))
 
@@ -61,6 +71,7 @@ Aliased imports
 import a/b.{c as d} as e
 import animal/cat as kitty
 import animal.{Cat as Kitty} as a
+import animal.{type Cat as Kitty} as a
 import animal.{}
 
 --------------------------------------------------------------------------------
@@ -75,6 +86,13 @@ import animal.{}
     alias: (identifier))
   (import
     module: (module)
+    alias: (identifier))
+  (import
+    module: (module)
+    imports: (unqualified_imports
+      (unqualified_import
+        name: (constructor_name)
+        alias: (constructor_name)))
     alias: (identifier))
   (import
     module: (module)

--- a/test/corpus/whole_files.txt
+++ b/test/corpus/whole_files.txt
@@ -161,7 +161,7 @@ pub fn negate(bool: Bool) -> Bool {
     module: (module)
     imports: (unqualified_imports
       (unqualified_import
-        name: (type_identifier))))
+        name: (constructor_name))))
   (statement_comment)
   (statement_comment)
   (statement_comment)
@@ -234,7 +234,7 @@ fn foo(a,) {
     (module)
     (unqualified_imports
       (unqualified_import
-        (type_identifier))))
+        (constructor_name))))
   (constant
     (identifier)
     (tuple_type

--- a/test/tags/frame.gleam
+++ b/test/tags/frame.gleam
@@ -1,8 +1,8 @@
-import gleam/option.{Option, Some, None}
+import gleam/option.{type Option, Some, None}
 //      ^ reference.module
-//                    ^ reference.type
-//                            ^ reference.type
-//                                  ^ reference.type
+//                        ^ reference.type
+//                                ^ reference.constructor
+//                                      ^ reference.constructor
 import gleam/bit_builder
 //      ^ reference.module
 


### PR DESCRIPTION
Gleam's import syntax used to not differentiate between type and value imports. That code was not changed when the `type` keyword was added to the type import syntax, meaning imported constructors were highlighted wrong.
This PR fixes that and highlights them correctly.