### PR TITLE
fix(go): remove redundant -I flag from CGo CFLAGS

### DIFF
--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -1,6 +1,6 @@
 package tree_sitter_gleam
 
-// #cgo CFLAGS: -std=c11 -fPIC -I${SRCDIR}/../../src
+// #cgo CFLAGS: -std=c11 -fPIC
 // #include "../../src/parser.c"
 // #if __has_include("../../src/scanner.c")
 // #include "../../src/scanner.c"

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,4 +1,4 @@
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 
 enum TokenType {
   QUOTED_CONTENT,


### PR DESCRIPTION
I was trying building the Go bindings but failed due to duplicate header resolution caused by `-I${SRCDIR}/../../src` in the CGo CFLAGS. The `#include "../../src/parser.c"` directives already resolve correctly via relative path, making the flag redundant.

Please correct me if this is not the right proper fix.