### PR TITLE
.gitignore more build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ gleam.so*
 log.html
 node_modules
 target
+*.a
+*.o
+*.pc
+*.so


### PR DESCRIPTION
The following files are showing up untracked by git for me after building the parser:
```
?? libtree-sitter-gleam.a
?? libtree-sitter-gleam.so
?? src/parser.o
?? src/scanner.o
?? tree-sitter-gleam.pc
```

Based on the [.gitignore file in the Rust treesitter](https://github.com/tree-sitter/tree-sitter-rust/blob/master/.gitignore), I added the following items to ignore:

```
*.a: C artifact
*.pc: C artifact
*.so: C artifact
*.o: Grammar volatile
```

Would it be preferable to completely replace the `.gitignore` file with the template from the Rust treesitter? I'm not sure what the canonical template is for this kind of project, but peeking at a few treesitters, they seem to all use a very similar set of ignores.